### PR TITLE
Bugfix: Option names being the same should be possible

### DIFF
--- a/src/scripts/builder.ts
+++ b/src/scripts/builder.ts
@@ -40,17 +40,12 @@ function extractObjects(sheets: Sheet[], key: string): MetadataItem[] {
     const { data = [] } = sheets.find(s => s.name === key) ?? {};
     const [header, ...rows] = data;
 
-    let sheetData = rows.map(row => _.fromPairs(row.map((cell, index) => [header[index].value, cell.value])));
-    if (key === "options") {
-        sheetData = sheetData.map(object => {
-            return { ...object, id: object.id ?? getUid(`${key}-${object.name}-${object.optionSet}`) } as MetadataItem;
-        });
-    } else {
-        sheetData = sheetData.map(object => {
-            return { ...object, id: object.id ?? getUid(`${key}-${object.name}`) } as MetadataItem;
-        });
-    }
-    return sheetData.filter(({ name }) => name !== undefined);
+    return rows.map(row => _.fromPairs(row.map((cell, index) => [header[index].value, cell.value])))
+        .map(object => {
+            const seed = `${key}-${object.name}` + (key === "options" ? "-" + object.optionSet : "");
+            return { ...object, id: object.id ?? getUid(seed) } as MetadataItem;
+        })
+        .filter(({ name }) => name !== undefined);
 }
 
 async function buildDataSets(sheets: Sheet[]) {

--- a/src/scripts/builder.ts
+++ b/src/scripts/builder.ts
@@ -40,12 +40,24 @@ function extractObjects(sheets: Sheet[], key: string): MetadataItem[] {
     const { data = [] } = sheets.find(s => s.name === key) ?? {};
     const [header, ...rows] = data;
 
-    return rows
-        .map(row => _.fromPairs(row.map((cell, index) => [header[index].value, cell.value])))
-        .map(object => {
+    let sheetData = rows.map(row => _.fromPairs(row.map((cell, index) => [header[index].value, cell.value])));
+    if (key === "options") {
+        sheetData = sheetData.map(object => {
+            return { ...object, id: object.id ?? getUid(`${key}-${object.name}-${object.optionSet}`) } as MetadataItem;
+        });
+        console.log(sheetData);
+    } else {
+        sheetData = sheetData.map(object => {
             return { ...object, id: object.id ?? getUid(`${key}-${object.name}`) } as MetadataItem;
-        })
-        .filter(({ name }) => name !== undefined);
+        });
+    }
+    return sheetData.filter(({ name }) => name !== undefined);
+    // return rows
+    //     .map(row => _.fromPairs(row.map((cell, index) => [header[index].value, cell.value])))
+    //     .map(object => {
+    //         return { ...object, id: object.id ?? getUid(`${key}-${object.name}`) } as MetadataItem;
+    //     })
+    //     .filter(({ name }) => name !== undefined);
 }
 
 async function buildDataSets(sheets: Sheet[]) {

--- a/src/scripts/builder.ts
+++ b/src/scripts/builder.ts
@@ -45,19 +45,12 @@ function extractObjects(sheets: Sheet[], key: string): MetadataItem[] {
         sheetData = sheetData.map(object => {
             return { ...object, id: object.id ?? getUid(`${key}-${object.name}-${object.optionSet}`) } as MetadataItem;
         });
-        console.log(sheetData);
     } else {
         sheetData = sheetData.map(object => {
             return { ...object, id: object.id ?? getUid(`${key}-${object.name}`) } as MetadataItem;
         });
     }
     return sheetData.filter(({ name }) => name !== undefined);
-    // return rows
-    //     .map(row => _.fromPairs(row.map((cell, index) => [header[index].value, cell.value])))
-    //     .map(object => {
-    //         return { ...object, id: object.id ?? getUid(`${key}-${object.name}`) } as MetadataItem;
-    //     })
-    //     .filter(({ name }) => name !== undefined);
 }
 
 async function buildDataSets(sheets: Sheet[]) {


### PR DESCRIPTION
Currently, this script only uses the name of the option to generate its ID, leading to a issue where _Options_ belonging to different _Option sets_ will get the same Id, failing the import.

The solution is to combine option name with optionSetName to generate the id.
Now is possible to repeat option names for different  _Option sets_, but, as intended, not for the same _Option set_.