### PR TITLE
Feature/Add missing fields to dataset

### DIFF
--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -73,8 +73,6 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     if (sheetName === "legends") return `${seed0}-${item.legendSet}`;
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
-    if (sheetName === "dataSetElements") return `${seed0}-${item.dataSet}`;
-    if (sheetName === "sectionsDataElements") return `${seed0}-${item.section}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;
     if (sheetName === "programStageSections") return `${seed0}-${item.program}-${item.programStage}`;
     if (sheetName === "programStageDataElements") return `${seed0}-${item.program}-${item.programStage}`;

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -73,6 +73,7 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     if (sheetName === "legends") return `${seed0}-${item.legendSet}`;
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
+    if (sheetName === "dataSetElements") return `${seed0}-${item.dataSet}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;
     if (sheetName === "programStageSections") return `${seed0}-${item.program}-${item.programStage}`;
     if (sheetName === "programStageDataElements") return `${seed0}-${item.program}-${item.programStage}`;

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -71,6 +71,7 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     const seed0 = `${sheetName}-${item.name}`; // the seed will be at least the page and the item's name
     if (sheetName === "options") return `${seed0}-${item.optionSet}`;
     if (sheetName === "legends") return `${seed0}-${item.legendSet}`;
+    if (sheetName === "sections") return `${seed0}-${item.dataSet}`;
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -74,6 +74,7 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
     if (sheetName === "dataSetElements") return `${seed0}-${item.dataSet}`;
+    if (sheetName === "sectionsDataElements") return `${seed0}-${item.section}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;
     if (sheetName === "programStageSections") return `${seed0}-${item.program}-${item.programStage}`;
     if (sheetName === "programStageDataElements") return `${seed0}-${item.program}-${item.programStage}`;

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -124,7 +124,6 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSetElements = get("dataSetElements");
     const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
-    const dataSetLegends = get("dataSetLegends");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
@@ -157,11 +156,7 @@ function buildDataSets(sheets: Sheet[]) {
             };
         });
 
-        data.legendSets = dataSetLegends.filter(dslToFilter => {
-            return dslToFilter.dataSet === data.name;
-        }).map(legend => {
-            return { id: legend.id };
-        });
+        data.legendSets = processItemLegendSets(sheets, data.name, "dataSet");
 
         replaceById(data, "categoryCombo", categoryCombos);
 
@@ -388,21 +383,13 @@ function buildTrackedEntityAttributes(sheets: Sheet[]) {
 
     const trackedEntityAttributes = get("trackedEntityAttributes");
     const optionSets = get("optionSets");
-    const legendSetsArray = get("legendSets");
-    const teasLegends = get("trackedEntityAttributesLegends").map(teasLegend => {
-        let data = { ...teasLegend } as MetadataItem;
-        data.id = getByName(legendSetsArray, teasLegend.name).id;
-        return data;
-    })
 
     return trackedEntityAttributes.map(trackedEntityAttribute => {
         let data = { ...trackedEntityAttribute } as MetadataItem;
 
         replaceById(data, "optionSet", optionSets);
 
-        const legendSets = teasLegends.filter(teasLegendToFilter => {
-            return teasLegendToFilter.trackedEntityAttribute === trackedEntityAttribute.name;
-        }).map(teasLegend => ({ id: teasLegend.id }));
+        const legendSets = processItemLegendSets(sheets, data.name, "trackedEntityAttribute");
 
         return { ...data, legendSets }
     });
@@ -505,6 +492,22 @@ function buildProgramRuleVariables(sheets: Sheet[]) {
         replaceById(data, "programStage", stages);
 
         return data;
+    });
+}
+
+// UTILS
+function processItemLegendSets(sheets: Sheet[], parentDataName: string, metadataType: string) {
+    const get = (name: string) => getItems(sheets, name);
+
+    const legendSets = get("legendSets");
+    const itemLegends = get(`${metadataType}Legends`);
+
+    return itemLegends.filter(itemLegendToFilter => {
+        return itemLegendToFilter[metadataType] === parentDataName;
+    }).map(legend => {
+        const legendId = getByName(legendSets, legend.name)?.id;
+
+        return { id: legendId };
     });
 }
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -137,6 +137,12 @@ function buildDataSets(sheets: Sheet[]) {
             };
         });
 
+        data.sections = dataSetSections.filter(dssToFilter => {
+            return dssToFilter.dataSet === data.name;
+        }).map(section => {
+            return { id: section.id };
+        });
+
         replaceById(data, "categoryCombo", categoryCombos);
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -122,6 +122,7 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSetElements = get("dataSetElements");
     const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
+    const dataSetsLegends = get("dataSetsLegends");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
@@ -152,6 +153,12 @@ function buildDataSets(sheets: Sheet[]) {
                 openingDate: inputPeriod.openingDate,
                 closingDate: inputPeriod.closingDate,
             };
+        });
+
+        data.legendSets = dataSetsLegends.filter(dslToFilter => {
+            return dslToFilter.dataSet === data.name;
+        }).map(legend => {
+            return { id: legend.id };
         });
 
         replaceById(data, "categoryCombo", categoryCombos);

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -120,6 +120,7 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSets = get("dataSets");
     const dataElements = get("dataElements");
     const dataSetElements = get("dataSetElements");
+    const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
     const categoryCombos = get("categoryCombos");
 
@@ -143,9 +144,19 @@ function buildDataSets(sheets: Sheet[]) {
             return { id: section.id };
         });
 
+        data.dataInputPeriods = dataSetInputPeriods.filter(dsipToFilter => {
+            return dsipToFilter.name === data.name;
+        }).map(inputPeriod => {
+            return {
+                period: { id: inputPeriod.period },
+                openingDate: inputPeriod.openingDate,
+                closingDate: inputPeriod.closingDate,
+            };
+        });
+
         replaceById(data, "categoryCombo", categoryCombos);
 
-        data.workflow = data.workflow ? { id: data.workflow } : undefined
+        data.workflow = data.workflow ? { id: data.workflow } : undefined;
 
         return { ...data };
     });

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -34,7 +34,8 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         .map(section => {
             const dataSet = sheetDataSets.find(({ name }) => name === section.dataSet)?.id;
             const dataElements = sheetSectionDataElements
-                .filter((item) => item.section === section.name)
+                .filter((item) => item.section === section.name &&
+                    item.dataSet === section.dataSet)
                 .map(({ name }) => ({ id: getByName(sheetDataElements, name).id }));
 
             return { ...section, dataSet: { id: dataSet }, dataElements };

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -10,6 +10,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     const sheetDataSets = get("dataSets"),
         sheetDataElements = get("dataElements"),
         sheetDataSetSections = get("sections"),
+        sheetSectionDataElements = get("sectionDataElements"),
         sheetCategoryCombos = get("categoryCombos"),
         sheetCategoryOptions = get("categoryOptions"),
         sheetCategories = get("categories"),
@@ -32,9 +33,9 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     const sections = _(sheetDataSetSections)
         .map(section => {
             const dataSet = sheetDataSets.find(({ name }) => name === section.dataSet)?.id;
-            const dataElements = sheetDataElements
-                .filter(({ dataSetSection }) => dataSetSection === section.name)
-                .map(({ id }) => ({ id }));
+            const dataElements = sheetSectionDataElements
+                .filter((item) => item.section === section.name)
+                .map(({ name }) => ({ id: getByName(sheetDataElements, name).id }));
 
             return { ...section, dataSet: { id: dataSet }, dataElements };
         })
@@ -122,7 +123,7 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSetElements = get("dataSetElements");
     const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
-    const dataSetsLegends = get("dataSetsLegends");
+    const dataSetLegends = get("dataSetLegends");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
@@ -155,7 +156,7 @@ function buildDataSets(sheets: Sheet[]) {
             };
         });
 
-        data.legendSets = dataSetsLegends.filter(dslToFilter => {
+        data.legendSets = dataSetLegends.filter(dslToFilter => {
             return dslToFilter.dataSet === data.name;
         }).map(legend => {
             return { id: legend.id };

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -58,27 +58,6 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         };
     });
 
-    const dataSets = sheetDataSets.map(dataSet => {
-        const dataSetElements = sheetDataElements
-            .filter(({ dataSetSection }) => {
-                const section = sheetDataSetSections.find(({ name }) => name === dataSetSection);
-                return section?.dataSet === dataSet.name;
-            })
-            .map(({ id, categoryCombo }) => {
-                const categoryComboId = sheetCategoryCombos.find(({ name }) => name === categoryCombo)?.id ?? defaultCC;
-
-                return {
-                    dataSet: { id: dataSet.id },
-                    dataElement: { id },
-                    categoryCombo: { id: categoryComboId },
-                };
-            });
-
-        const categoryCombo = sheetCategoryCombos.find(({ name }) => name === dataSet.categoryCombo)?.id ?? defaultCC;
-
-        return { ...dataSet, dataSetElements, categoryCombo: { id: categoryCombo } };
-    });
-
     const categories = sheetCategories.map(category => {
         const categoryOptions = sheetCategoryOptions
             .filter(option => option.category === category.name)
@@ -114,7 +93,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     });
 
     return {
-        dataSets,
+        dataSets: buildDataSets(sheets, defaultCC),
         dataElements: [...dataElements, ...programDataElements],
         options,
         sections,
@@ -133,6 +112,36 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         programRuleVariables: buildProgramRuleVariables(sheets),
         legendSets: buildLegendSets(sheets),
     };
+}
+
+function buildDataSets(sheets: Sheet[], defaultCC: string) {
+    const get = (name: string) => getItems(sheets, name);
+
+    const dataSets = get("dataSets");
+    const dataElements = get("dataElements");
+    const dataSetSections = get("sections");
+    const categoryCombos = get("categoryCombos");
+
+    return dataSets.map(dataSet => {
+        const dataSetElements = dataElements
+            .filter(({ dataSetSection }) => {
+                const section = dataSetSections.find(({ name }) => name === dataSetSection);
+                return section?.dataSet === dataSet.name;
+            })
+            .map(({ id, categoryCombo }) => {
+                const categoryComboId = categoryCombos.find(({ name }) => name === categoryCombo)?.id ?? defaultCC;
+
+                return {
+                    dataSet: { id: dataSet.id },
+                    dataElement: { id },
+                    categoryCombo: { id: categoryComboId },
+                };
+            });
+
+        const categoryCombo = categoryCombos.find(({ name }) => name === dataSet.categoryCombo)?.id ?? defaultCC;
+
+        return { ...dataSet, dataSetElements, categoryCombo: { id: categoryCombo } };
+    });
 }
 
 function buildPrograms(sheets: Sheet[]) {

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -119,22 +119,21 @@ function buildDataSets(sheets: Sheet[]) {
 
     const dataSets = get("dataSets");
     const dataElements = get("dataElements");
+    const dataSetElements = get("dataSetElements");
     const dataSetSections = get("sections");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
         let data: MetadataItem = JSON.parse(JSON.stringify(dataSet));
 
-        const dataSetElements = dataElements.filter(({ dataSetSection }) => {
-            const section = getByName(dataSetSections, dataSetSection);
-            return section?.dataSet === data.name;
-        }).map(({ id, categoryCombo }) => {
-            const categoryComboId = getByName(categoryCombos, categoryCombo)?.id;
-
+        data.dataSetElements = dataSetElements.filter(dseToFilter => {
+            return dseToFilter.dataSet === data.name;
+        }).map(elements => {
             return {
                 dataSet: { id: data.id },
-                dataElement: { id },
-                categoryCombo: { id: categoryComboId },
+                dataElement: { id: getByName(dataElements, elements.name).id },
+                categoryCombo: elements.categoryCombo ?
+                    { id: getByName(categoryCombos, elements.categoryCombo).id } : undefined,
             };
         });
 
@@ -142,7 +141,7 @@ function buildDataSets(sheets: Sheet[]) {
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined
 
-        return { ...data, dataSetElements };
+        return { ...data };
     });
 }
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -140,6 +140,8 @@ function buildDataSets(sheets: Sheet[]) {
 
         replaceById(data, "categoryCombo", categoryCombos);
 
+        data.workflow = data.workflow ? { id: data.workflow } : undefined
+
         return { ...data, dataSetElements };
     });
 }


### PR DESCRIPTION
### :pushpin: References

**Issue:**  [Add missing fields to dataset](https://app.clickup.com/t/3h1umfz)

### :memo: Implementation

This branch implements: 
- Adds missing fields from dataSet, except Indicators and OrgUnits (these metadata items are not implemented in the script yet). Workflow field is partially implemented allowing to reference an existing workflow in an DHIS2 instance inputting its UID in this field. Otherwise it can be left empty.
- The dataElements can now be assigned to multiple dataSets via the dataSetElements spreadsheet tab.
- Added dataElements categoryCombo override.
- New spreadsheet tabs: 
  - dataSetElements: Columns: [dataSet | name | categoryCombo]. The field name is for dataElement name, categoryCombo field is for categoryCombo override.
  - dataSetInputPeriods: Columns: [name | period | openingDate | closingDate]. The field name is for dataSet name.
  - dataSetLegends: Columns: [dataSet | name]. The field name is for legendSet name.
- Modified spreadsheet tabs:
  - dataSets: Columns added: [shortName | expiryDays | openFuturePeriods | timelyDays | notifyCompletingUser | workflow | mobile | fieldCombinationRequired | validCompleteOnly | noValueRequiresComment | skipOffline | dataElementDecoration | renderAsTabs | renderHorizontally | compulsoryFieldsCompleteOnly]
  - dataElements: Columns removed: [dataSetSection]

### :fire: Notes to the tester


