### PR TITLE
Feature/add data element groups and sets

### DIFF
--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -97,6 +97,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         dataSets: buildDataSets(sheets),
         dataElements: [...dataElements, ...programDataElements],
         dataElementGroups: buildDataElementGroups(sheets),
+        dataElementGroupSets: buildDataElementGroupSets(sheets),
         options,
         sections,
         categories,
@@ -178,14 +179,36 @@ function buildDataElementGroups(sheets: Sheet[]) {
     const dataElementGroupElements = get("dataElementGroupElements");
     const dataElements = get("dataElements");
 
-    return dataElementGroups.map(deGroup => {
-        let data: MetadataItem = JSON.parse(JSON.stringify(deGroup));
+    return dataElementGroups.map(degGroup => {
+        let data: MetadataItem = JSON.parse(JSON.stringify(degGroup));
 
         data.dataElements = dataElementGroupElements.filter(degeToFilter => {
             return degeToFilter.dataElementGroup === data.name;
         }).map(elements => {
             return {
                 id: getByName(dataElements, elements.name).id,
+            };
+        });
+
+        return { ...data };
+    });
+}
+
+function buildDataElementGroupSets(sheets: Sheet[]) {
+    const get = (name: string) => getItems(sheets, name);
+
+    const dataElementGroupSets = get("dataElementGroupSets");
+    const dataElementGroupSetGroups = get("dataElementGroupSetGroups");
+    const dataElementGroups = get("dataElementGroups");
+
+    return dataElementGroupSets.map(degsGroup => {
+        let data: MetadataItem = JSON.parse(JSON.stringify(degsGroup));
+
+        data.dataElementGroups = dataElementGroupSetGroups.filter(degsgToFilter => {
+            return degsgToFilter.dataElementGroupSet === data.name;
+        }).map(groups => {
+            return {
+                id: getByName(dataElementGroups, groups.name).id,
             };
         });
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -96,6 +96,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     return {
         dataSets: buildDataSets(sheets),
         dataElements: [...dataElements, ...programDataElements],
+        dataElementGroups: buildDataElementGroups(sheets),
         options,
         sections,
         categories,
@@ -165,6 +166,28 @@ function buildDataSets(sheets: Sheet[]) {
         replaceById(data, "categoryCombo", categoryCombos);
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined;
+
+        return { ...data };
+    });
+}
+
+function buildDataElementGroups(sheets: Sheet[]) {
+    const get = (name: string) => getItems(sheets, name);
+
+    const dataElementGroups = get("dataElementGroups");
+    const dataElementGroupElements = get("dataElementGroupElements");
+    const dataElements = get("dataElements");
+
+    return dataElementGroups.map(deGroup => {
+        let data: MetadataItem = JSON.parse(JSON.stringify(deGroup));
+
+        data.dataElements = dataElementGroupElements.filter(degeToFilter => {
+            return degeToFilter.dataElementGroup === data.name;
+        }).map(elements => {
+            return {
+                id: getByName(dataElements, elements.name).id,
+            };
+        });
 
         return { ...data };
     });


### PR DESCRIPTION
### :pushpin: References

**Issue:**  [Add DE group](https://app.clickup.com/t/3h1umua)

### :memo: Implementation

This branch implements: 
- Add processing for dataElementGroups and dataElementGroupSets.
- New spreadsheet tabs: 
  - dataElementGroups: Columns: [id | name | shortName | code | description].
  - dataElementGroupElements: [dataElementGroup | name]. The field name is for dataElement name.
  - dataElementGroupSets: [id | name | shortName | code | description | compulsory | dataDimension].
  - dataElementGroupSetGroups: [dataElementGroupSet | name]. The field name is for dataElementGroup name.

### :fire: Notes to the tester