### PR TITLE
Feature/add attributes to data sets

### DIFF
--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -73,8 +73,6 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     if (sheetName === "legends") return `${seed0}-${item.legendSet}`;
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
-    if (sheetName === "dataSetElements") return `${seed0}-${item.dataSet}`;
-    if (sheetName === "sectionsDataElements") return `${seed0}-${item.section}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;
     if (sheetName === "programStageSections") return `${seed0}-${item.program}-${item.programStage}`;
     if (sheetName === "programStageDataElements") return `${seed0}-${item.program}-${item.programStage}`;

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -73,6 +73,7 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     if (sheetName === "legends") return `${seed0}-${item.legendSet}`;
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
+    if (sheetName === "dataSetElements") return `${seed0}-${item.dataSet}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;
     if (sheetName === "programStageSections") return `${seed0}-${item.program}-${item.programStage}`;
     if (sheetName === "programStageDataElements") return `${seed0}-${item.program}-${item.programStage}`;

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -74,6 +74,7 @@ function makeSeed(item: MetadataItem, sheetName: string) {
     if (sheetName === "programStages") return `${seed0}-${item.program}`;
     if (sheetName === "programSections") return `${seed0}-${item.program}`;
     if (sheetName === "dataSetElements") return `${seed0}-${item.dataSet}`;
+    if (sheetName === "sectionsDataElements") return `${seed0}-${item.section}`;
     if (sheetName === "programTrackedEntityAttributes") return `${seed0}-${item.program}`;
     if (sheetName === "programStageSections") return `${seed0}-${item.program}-${item.programStage}`;
     if (sheetName === "programStageDataElements") return `${seed0}-${item.program}-${item.programStage}`;

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -262,15 +262,16 @@ function buildAttributes(sheets: Sheet[]) {
     return attributes.map(attribute => {
         let data: MetadataItem = JSON.parse(JSON.stringify(attribute));
 
-        data.optionSet = {
-            id: optionSets.find(osToFilter => {
-                return osToFilter.name === data.optionSet;
-            })?.id
-        };
+        const optionSetId = optionSets.find(osToFilter => {
+            return osToFilter.name === data.optionSet;
+        })?.id;
+        const optionSet = optionSetId ? {
+            id: optionSetId,
+        } : undefined;
 
         data.translation = buildTranslation(sheets, data, "attribute");
 
-        return { ...data };
+        return { ...data, optionSet };
     });
 }
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -137,6 +137,12 @@ function buildDataSets(sheets: Sheet[]) {
             };
         });
 
+        data.sections = dataSetSections.filter(dssToFilter => {
+            return dssToFilter.dataSet === data.name;
+        }).map(section => {
+            return { id: section.id };
+        });
+
         replaceById(data, "categoryCombo", categoryCombos);
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -122,6 +122,7 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSetElements = get("dataSetElements");
     const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
+    const dataSetsLegends = get("dataSetsLegends");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
@@ -152,6 +153,12 @@ function buildDataSets(sheets: Sheet[]) {
                 openingDate: inputPeriod.openingDate,
                 closingDate: inputPeriod.closingDate,
             };
+        });
+
+        data.legendSets = dataSetsLegends.filter(dslToFilter => {
+            return dslToFilter.dataSet === data.name;
+        }).map(legend => {
+            return { id: legend.id };
         });
 
         replaceById(data, "categoryCombo", categoryCombos);

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -60,6 +60,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         const optionSet = sheetOptionSets.find(({ name }) => name === dataElement.optionSet)?.id;
 
         const translation = buildTranslation(sheets, dataElement, "dataElement");
+        const attributeValues = processItemAttributes(sheets, dataElement, "dataElement");
 
         return {
             ...dataElement,
@@ -67,6 +68,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
             optionSet: optionSet ? { id: optionSet } : undefined,
             domainType: "AGGREGATE",
             translation: translation,
+            attributeValues: attributeValues,
         };
     });
 
@@ -108,12 +110,14 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         const optionSet = sheetOptionSets.find(({ name }) => name === dataElement.optionSet)?.id;
 
         const translation = buildTranslation(sheets, dataElement, "programDataElement");
+        const attributeValues = processItemAttributes(sheets, dataElement, "DataElement");
 
         return {
             ...dataElement,
             domainType: "TRACKER",
             optionSet: optionSet ? { id: optionSet } : undefined,
             translation: translation,
+            attributeValues: attributeValues,
         };
     });
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -185,7 +185,7 @@ function buildDataSets(sheets: Sheet[]) {
 
         data.translation = buildTranslation(sheets, data, "dataSet");
 
-        data.attributeValues = processItemAtributes(sheets, data, "dataSet");
+        data.attributeValues = processItemAttributes(sheets, data, "dataSet");
 
         replaceById(data, "categoryCombo", categoryCombos);
 
@@ -560,7 +560,7 @@ function buildTranslation(sheets: Sheet[], parentData: MetadataItem, metadataTyp
     });
 }
 
-function processItemAtributes(sheets: Sheet[], parentData: MetadataItem, metadataType: string) {
+function processItemAttributes(sheets: Sheet[], parentData: MetadataItem, metadataType: string) {
     const get = (name: string) => getItems(sheets, name);
     const attributes = get("attributes");
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -120,6 +120,7 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSets = get("dataSets");
     const dataElements = get("dataElements");
     const dataSetElements = get("dataSetElements");
+    const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
     const categoryCombos = get("categoryCombos");
 
@@ -143,9 +144,19 @@ function buildDataSets(sheets: Sheet[]) {
             return { id: section.id };
         });
 
+        data.dataInputPeriods = dataSetInputPeriods.filter(dsipToFilter => {
+            return dsipToFilter.name === data.name;
+        }).map(inputPeriod => {
+            return {
+                period: { id: inputPeriod.period },
+                openingDate: inputPeriod.openingDate,
+                closingDate: inputPeriod.closingDate,
+            };
+        });
+
         replaceById(data, "categoryCombo", categoryCombos);
 
-        data.workflow = data.workflow ? { id: data.workflow } : undefined
+        data.workflow = data.workflow ? { id: data.workflow } : undefined;
 
         return { ...data };
     });

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -10,6 +10,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     const sheetDataSets = get("dataSets"),
         sheetDataElements = get("dataElements"),
         sheetDataSetSections = get("sections"),
+        sheetSectionDataElements = get("sectionDataElements"),
         sheetCategoryCombos = get("categoryCombos"),
         sheetCategoryOptions = get("categoryOptions"),
         sheetCategories = get("categories"),
@@ -32,9 +33,9 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     const sections = _(sheetDataSetSections)
         .map(section => {
             const dataSet = sheetDataSets.find(({ name }) => name === section.dataSet)?.id;
-            const dataElements = sheetDataElements
-                .filter(({ dataSetSection }) => dataSetSection === section.name)
-                .map(({ id }) => ({ id }));
+            const dataElements = sheetSectionDataElements
+                .filter((item) => item.section === section.name)
+                .map(({ name }) => ({ id: getByName(sheetDataElements, name).id }));
 
             return { ...section, dataSet: { id: dataSet }, dataElements };
         })
@@ -122,7 +123,7 @@ function buildDataSets(sheets: Sheet[]) {
     const dataSetElements = get("dataSetElements");
     const dataSetInputPeriods = get("dataSetInputPeriods");
     const dataSetSections = get("sections");
-    const dataSetsLegends = get("dataSetsLegends");
+    const dataSetLegends = get("dataSetLegends");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
@@ -155,7 +156,7 @@ function buildDataSets(sheets: Sheet[]) {
             };
         });
 
-        data.legendSets = dataSetsLegends.filter(dslToFilter => {
+        data.legendSets = dataSetLegends.filter(dslToFilter => {
             return dslToFilter.dataSet === data.name;
         }).map(legend => {
             return { id: legend.id };

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -58,27 +58,6 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         };
     });
 
-    const dataSets = sheetDataSets.map(dataSet => {
-        const dataSetElements = sheetDataElements
-            .filter(({ dataSetSection }) => {
-                const section = sheetDataSetSections.find(({ name }) => name === dataSetSection);
-                return section?.dataSet === dataSet.name;
-            })
-            .map(({ id, categoryCombo }) => {
-                const categoryComboId = sheetCategoryCombos.find(({ name }) => name === categoryCombo)?.id ?? defaultCC;
-
-                return {
-                    dataSet: { id: dataSet.id },
-                    dataElement: { id },
-                    categoryCombo: { id: categoryComboId },
-                };
-            });
-
-        const categoryCombo = sheetCategoryCombos.find(({ name }) => name === dataSet.categoryCombo)?.id ?? defaultCC;
-
-        return { ...dataSet, dataSetElements, categoryCombo: { id: categoryCombo } };
-    });
-
     const categories = sheetCategories.map(category => {
         const categoryOptions = sheetCategoryOptions
             .filter(option => option.category === category.name)
@@ -114,7 +93,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
     });
 
     return {
-        dataSets,
+        dataSets: buildDataSets(sheets, defaultCC),
         dataElements: [...dataElements, ...programDataElements],
         options,
         sections,
@@ -133,6 +112,36 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         programRuleVariables: buildProgramRuleVariables(sheets),
         legendSets: buildLegendSets(sheets),
     };
+}
+
+function buildDataSets(sheets: Sheet[], defaultCC: string) {
+    const get = (name: string) => getItems(sheets, name);
+
+    const dataSets = get("dataSets");
+    const dataElements = get("dataElements");
+    const dataSetSections = get("sections");
+    const categoryCombos = get("categoryCombos");
+
+    return dataSets.map(dataSet => {
+        const dataSetElements = dataElements
+            .filter(({ dataSetSection }) => {
+                const section = dataSetSections.find(({ name }) => name === dataSetSection);
+                return section?.dataSet === dataSet.name;
+            })
+            .map(({ id, categoryCombo }) => {
+                const categoryComboId = categoryCombos.find(({ name }) => name === categoryCombo)?.id ?? defaultCC;
+
+                return {
+                    dataSet: { id: dataSet.id },
+                    dataElement: { id },
+                    categoryCombo: { id: categoryComboId },
+                };
+            });
+
+        const categoryCombo = categoryCombos.find(({ name }) => name === dataSet.categoryCombo)?.id ?? defaultCC;
+
+        return { ...dataSet, dataSetElements, categoryCombo: { id: categoryCombo } };
+    });
 }
 
 function buildPrograms(sheets: Sheet[]) {

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -185,6 +185,8 @@ function buildDataSets(sheets: Sheet[]) {
 
         data.translation = buildTranslation(sheets, data, "dataSet");
 
+        data.attributeValues = processItemAtributes(sheets, data, "dataSet");
+
         replaceById(data, "categoryCombo", categoryCombos);
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined;
@@ -555,6 +557,26 @@ function buildTranslation(sheets: Sheet[], parentData: MetadataItem, metadataTyp
             locale: locale,
             value: translation.value,
         } : {};
+    });
+}
+
+function processItemAtributes(sheets: Sheet[], parentData: MetadataItem, metadataType: string) {
+    const get = (name: string) => getItems(sheets, name);
+    const attributes = get("attributes");
+
+    return attributes.filter(attribute => {
+        return attribute[`${metadataType}Attribute`] === "TRUE";
+    }).flatMap(atribute => {
+        const value = parentData[atribute.name];
+        delete parentData[atribute.name];
+
+        return value ? {
+            value: value,
+            attribute: {
+                id: atribute.id,
+                name: atribute.name,
+            },
+        } : [];
     });
 }
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -119,22 +119,21 @@ function buildDataSets(sheets: Sheet[]) {
 
     const dataSets = get("dataSets");
     const dataElements = get("dataElements");
+    const dataSetElements = get("dataSetElements");
     const dataSetSections = get("sections");
     const categoryCombos = get("categoryCombos");
 
     return dataSets.map(dataSet => {
         let data: MetadataItem = JSON.parse(JSON.stringify(dataSet));
 
-        const dataSetElements = dataElements.filter(({ dataSetSection }) => {
-            const section = getByName(dataSetSections, dataSetSection);
-            return section?.dataSet === data.name;
-        }).map(({ id, categoryCombo }) => {
-            const categoryComboId = getByName(categoryCombos, categoryCombo)?.id;
-
+        data.dataSetElements = dataSetElements.filter(dseToFilter => {
+            return dseToFilter.dataSet === data.name;
+        }).map(elements => {
             return {
                 dataSet: { id: data.id },
-                dataElement: { id },
-                categoryCombo: { id: categoryComboId },
+                dataElement: { id: getByName(dataElements, elements.name).id },
+                categoryCombo: elements.categoryCombo ?
+                    { id: getByName(categoryCombos, elements.categoryCombo).id } : undefined,
             };
         });
 
@@ -142,7 +141,7 @@ function buildDataSets(sheets: Sheet[]) {
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined
 
-        return { ...data, dataSetElements };
+        return { ...data };
     });
 }
 

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -112,6 +112,7 @@ export function buildMetadata(sheets: Sheet[], defaultCC: string) {
         programRuleActions: buildProgramRuleActions(sheets),
         programRuleVariables: buildProgramRuleVariables(sheets),
         legendSets: buildLegendSets(sheets),
+        attributes: buildAttributes(sheets),
     };
 }
 
@@ -165,6 +166,25 @@ function buildDataSets(sheets: Sheet[]) {
         replaceById(data, "categoryCombo", categoryCombos);
 
         data.workflow = data.workflow ? { id: data.workflow } : undefined;
+
+        return { ...data };
+    });
+}
+
+function buildAttributes(sheets: Sheet[]) {
+    const get = (name: string) => getItems(sheets, name);
+
+    const attributes = get("attributes");
+    const optionSets = get("optionSets");
+
+    return attributes.map(attribute => {
+        let data: MetadataItem = JSON.parse(JSON.stringify(attribute));
+
+        data.optionSet = {
+            id: optionSets.find(osToFilter => {
+                return osToFilter.name === data.optionSet;
+            })?.id
+        };
 
         return { ...data };
     });

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -140,6 +140,8 @@ function buildDataSets(sheets: Sheet[]) {
 
         replaceById(data, "categoryCombo", categoryCombos);
 
+        data.workflow = data.workflow ? { id: data.workflow } : undefined
+
         return { ...data, dataSetElements };
     });
 }

--- a/src/utils/buildMetadata.ts
+++ b/src/utils/buildMetadata.ts
@@ -208,6 +208,8 @@ function buildAttributes(sheets: Sheet[]) {
             })?.id
         };
 
+        data.translation = buildTranslation(sheets, data, "attribute");
+
         return { ...data };
     });
 }


### PR DESCRIPTION
### :pushpin: References

**Issue:**  [Add attributes (in particular dataset)](https://app.clickup.com/t/3h1umdf)

### :memo: Implementation

This branch implements: 
- Add processing of attributes tab.
- A generic attributes processing function that will work with fields added to dataSets if they are present in attributes tab and have the correct flag (dataSetAttribute).
- Adds translations to attributes.

- New spreadsheet tabs: 
  - attributes: Columns: [id | name | shortName | code | description | valueType | optionSet | sortOrder | mandatory | unique | dataSetAttribute | dataElementAttribute | indicatorAttribute | indicatorGroupAttribute | userGroupAttribute | constantAttribute | categoryOptionAttribute | optionSetAttribute | sqlViewAttribute | legendSetAttribute | trackedEntityAttributeAttribute | organisationUnitAttribute | documentAttribute | validationRuleGroupAttribute | dataElementGroupAttribute | sectionAttribute | trackedEntityTypeAttribute | userAttribute | categoryOptionGroupAttribute | programStageAttribute | programAttribute | categoryAttribute | categoryOptionComboAttribute | categoryOptionGroupSetAttribute | validationRuleAttribute | programIndicatorAttribute | organisationUnitGroupAttribute | dataElementGroupSetAttribute | organisationUnitGroupSetAttribute | optionAttribute].
  - attributeTranslations: Columns: [attribute | name | locale | value]. The field name is for property name.
 - Modified spreadsheet tabs:
   - dataSets: The attributes can be added as new columns.
   - dataElements: The attributes can be added as new columns.
